### PR TITLE
Fix improper specs that cause Dialyzer warnings

### DIFF
--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -76,7 +76,7 @@ defmodule Confex do
     iex> [test: "defaults"] = #{__MODULE__}.process_env([test: {:system, "some_test_var", "defaults"}])
     [test: "defaults"]
   """
-  @spec process_env(Keyword.t | atom | String.t | Integer.t) :: Keyword.t
+  @spec process_env(Keyword.t | atom | String.t | Integer.t) :: term
   def process_env(conf) when is_list(conf) do
     prepare_list(conf)
   end
@@ -188,6 +188,8 @@ defmodule Confex do
   # Helper to include configs into module and validate it at compile-time/run-time
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
+      @dialyzer {:nowarn_function, add_defaults: 2}
+
       @otp_app opts
       |> Keyword.get(:otp_app)
 


### PR DESCRIPTION
* Fix `process_env/1` incorrect spec, that caused a lot of warnings in my project (I use `Confex.process_env/1` directly)
* Add `@dialyzer {:nowarn_function, add_defaults: 2}` to the module that uses Confex to prevent warnings like:
```
lib/mail_courier/connection.ex:13: The pattern <_@1, 'nil'> can never match the type <[{atom(),_}],[{'adapter','amqp'} | {'backoff',[any(),...]},...]>
lib/mail_courier/connection.ex:13: The pattern <'nil', _@1> can never match the type <[{atom(),_}],[{'adapter','amqp'} | {'backoff',[any(),...]},...]>
```