### PR TITLE
File Loader for Config

### DIFF
--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -192,7 +192,6 @@ defmodule Confex do
     else: directory_path <> "/"
   end
 
-
   # If there is no environment variable for `key`, lets check our
   # file_config_directory
   defp load_from_file(nil, key) do

--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -197,7 +197,7 @@ defmodule Confex do
   defp load_from_file(nil, key) do
     file_name = get_file_config_directory <> key
 
-    config = with :true <- File.exists?(file_name) do
+    config_value = with :true <- File.exists?(file_name) do
       {:ok, value} = File.read(file_name)
       value
     else

--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -181,13 +181,12 @@ defmodule Confex do
   end
 
   defp get_file_config_directory do
-    Application.get_env(:confex, :file_config_directory, System.tmp_dir)
-    |> sanitize_path
+    sanitize_path(Application.get_env(:confex, :file_config_directory, System.tmp_dir))
   end
 
   # Handle directory paths with and without a trailing /
   defp sanitize_path(directory_path) do
-    if :true == String.ends_with?(directory_path, "/"),
+    if String.ends_with?(directory_path, "/"),
     do: directory_path,
     else: directory_path <> "/"
   end

--- a/test/unit/confex_test.exs
+++ b/test/unit/confex_test.exs
@@ -28,6 +28,52 @@ defmodule ConfexTest do
             map: %{key: {:system, "THIS_DOESNT_WORK"}}] = Confex.get_map(:confex, __MODULE__)
   end
 
+  test "loading config from files" do
+    file_key = Integer.to_string(:os.system_time(:seconds))
+    File.write("#{System.tmp_dir}/#{file_key}", "my-super-secret-value")
+
+    Application.put_env(:confex, __MODULE__, [
+      secret: {:system, file_key}
+    ])
+
+    assert [secret: "my-super-secret-value"] = Confex.get_map(:confex, __MODULE__)
+
+    File.rm(System.tmp_dir <> "/#{file_key}")
+  end
+
+  test "file_config_directory can handle paths with and without trailing /" do
+    File.mkdir("/#{System.tmp_dir}/new_dir")
+    Application.put_env(:confex, :file_config_directory, "/#{System.tmp_dir}/new_dir/")
+
+    file_key = Integer.to_string(:os.system_time(:seconds))
+    File.write("#{System.tmp_dir}/new_dir/#{file_key}", "my-super-secret-value")
+
+    Application.put_env(:confex, __MODULE__, [
+      secret: {:system, file_key}
+    ])
+
+    assert [secret: "my-super-secret-value"] = Confex.get_map(:confex, __MODULE__)
+
+    File.rmdir("#{System.tmp_dir}/new_dir")
+
+  end
+
+  test "file_config_directory can be overridden" do
+    File.mkdir("/#{System.tmp_dir}/new_dir")
+    Application.put_env(:confex, :file_config_directory, "/#{System.tmp_dir}/new_dir")
+
+    file_key = Integer.to_string(:os.system_time(:seconds))
+    File.write("/#{System.tmp_dir}/new_dir/#{file_key}", "my-super-secret-value")
+
+    Application.put_env(:confex, __MODULE__, [
+      secret: {:system, file_key}
+    ])
+
+    assert [secret: "my-super-secret-value"] = Confex.get_map(:confex, __MODULE__)
+
+    File.rmdir("/#{System.tmp_dir}/new_dir")
+  end
+
   test "sets integers" do
     Application.put_env(:confex, __MODULE__, [
        a: {:system, :integer, "TESTENV"},


### PR DESCRIPTION
Adding support for providing a file_configuration_directory and pulling in values from disk.

This will allow Elixir developers to easily run their applications on Docker Swarm, Mesos and Kubernetes and consume their secrets, which tend to be stored in `/run/secrets/key`

Signed-off-by: David McKay <david@rawkode.com>