### PR TITLE
Support for comma-separated lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ It's available on [hex.pm](https://hex.pm/packages/confex) and can be installed 
     * `{:system, :atom, "ENV_NAME", :default}`
     * `{:system, :module, "ENV_NAME"}`
     * `{:system, :module, "ENV_NAME", Default}`
+    * `{:system, :list, "ENV_NAME"}` - same as `{:system, :list, "ENV_NAME", nil}`.
+    * `{:system, :list, "ENV_NAME", Default}` - same as `{:system, "ENV_NAME", default}`, but will convert value to list if it's not `nil`, splitting at commas. Default value type **will not** be changed.
 
 2. Reading configuration
 

--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -128,6 +128,9 @@ defmodule Confex do
   defp get_value({:system, :module, var_name}),
    do: get_value({:system, :module, var_name, nil})
 
+  defp get_value({:system, :list, var_name}),
+   do: get_value({:system, :list, var_name, nil})
+
   defp get_value({:system, var_name, default_value}),
    do: get_value({:system, :string, var_name, default_value})
 
@@ -177,6 +180,14 @@ defmodule Confex do
       true ->
         nil
     end
+  end
+
+  @list_separator ","
+
+  defp cast(value, :list) when is_binary(value) do
+    value
+    |> String.split(@list_separator)
+    |> Enum.map(&String.trim/1)
   end
 
 

--- a/test/unit/confex_test.exs
+++ b/test/unit/confex_test.exs
@@ -145,6 +145,16 @@ defmodule ConfexTest do
     assert [a: MyModule] = Confex.get_map(:confex, __MODULE__)
   end
 
+  test "sets lists" do
+    System.put_env("TESTENV", "foo, bar, baz")
+
+    Application.put_env(:confex, __MODULE__, [
+       a: {:system, :list, "TESTENV"}
+    ])
+
+    assert [a: ["foo", "bar", "baz"]] = Confex.get_map(:confex, __MODULE__)
+  end
+
   test "walks on nested maps" do
     Application.put_env(:confex, __MODULE__, [
        a: [aa: "bar",


### PR DESCRIPTION
I ran into a use case where I wanted to set a list through the environment, and I figured that extending Confex directly might benefit others.