### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ defmodule MyApp do
   """
   def init(_, config) do
     url = System.get_env("DATABASE_URL")
-    config = if url, do: Ecto.Repo.Supervisor.parse_url(url), else: Confex.process_env(config)
+    config = if url,
+      do: Keyword.merge(config, Ecto.Repo.Supervisor.parse_url(url)),
+      else: Confex.process_env(config)
 
     unless config[:database] do
       raise "Set DB_NAME environment variable!"


### PR DESCRIPTION
Without the original **config** the **:otp_app** key is missing, when config comes from **url**