### PR TITLE
Fix Elixir 1.5 deprecation warnings

### DIFF
--- a/lib/confex/type.ex
+++ b/lib/confex/type.ex
@@ -53,7 +53,7 @@ defmodule Confex.Type do
   def cast(value, :atom) do
     result =
       value
-      |> String.to_char_list()
+      |> String.to_charlist()
       |> List.to_atom()
 
     {:ok, result}


### PR DESCRIPTION
Elixir 1.5 deprecated `String.to_char_list/1` in favor of `String.to_charlist/1`.
`Confex` requires Elixir `~> 1.4`, so it's safe to replace.