### PR TITLE
Fixed Confex.get_env/3 docs

### DIFF
--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -157,7 +157,7 @@ defmodule Confex do
   end
 
   @doc """
-  Returns the value for key in app’s environment in a tuple.
+  Returns the value for key in app’s environment.
   This function mimics `Application.get_env/2` function.
 
   If the configuration parameter does not exist or can not be parsed, returns default value or `nil`.


### PR DESCRIPTION
`get_env` returns the value directly, or `nil` if it is not set. It does not return a tuple.