### PR TITLE
Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It's available on [hex.pm](https://hex.pm/packages/confex) and can be installed 
     * `{:system, :module, "ENV_NAME"}`.
     * `{:system, :module, "ENV_NAME", MyDefault}`.
     * `{:system, :list, "ENV_NAME"}`.
-    * `{:system, :list, "ENV_NAME", [1, 2, 3]}`.
+    * `{:system, :list, "ENV_NAME", ["a", "b", "c"]}`.
 
     `:system` can be replaced with a `{:via, adapter}` tuple, where adapter is a module that implements `Confex.Adapter` behaviour.
 


### PR DESCRIPTION
Try being more specific about how `{:system, :list, ...}` works. The current README falsely suggests that the list will be parsed into integers, which is not how it is implemented. This patch adjusts the default value in the example to the same typing as what the resolver would produce from an environment variable.