### PR TITLE
Extend instalation guide for Elixir 1.4.0 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It's available on [hex.pm](https://hex.pm/packages/confex) and can be installed 
       end
       ```
 
-  2. Ensure `confex` is started before your application:
+  2. Ensure `confex` is started before your application (Don't add it for the apps using Elixir 1.4.0 or newer):
 
       ```elixir
       def application do

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It's available on [hex.pm](https://hex.pm/packages/confex) and can be installed 
       end
       ```
 
-  2. Ensure `confex` is started before your application (Don't add it for the apps using Elixir 1.4.0 or newer):
+  2. Ensure `confex` is started before your application either by adding it to `applications` list as shown below or by making sure you use `extra_applications` option instead of `applications` (this feature is available since Elixir 1.4 and enabled by default for new projects): 
 
       ```elixir
       def application do


### PR DESCRIPTION
I had some problems with using `Confex` for my first Project based on Elixir 1.7.4. I think it's worth to extend Readme file a little and add an information about using applications list only for Projects using Elixir older than v1.4.0 (source: https://elixir-lang.org/blog/2017/01/05/elixir-v1-4-0-released/#application-inference). Hope you like it! ;-) 

