### PR TITLE
add base64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ It's available on [hex.pm](https://hex.pm/packages/confex) and can be installed 
     * `{:system, :list, "ENV_NAME", ["a", "b", "c"]}`.
     * `{:system, :charlist, "ENV_NAME"}`.
     * `{:system, :charlist, "ENV_NAME", 'default'}`.
+    * `{:system, :base64, "ENV_NAME"}`.
+    * `{:system, :base64, "ENV_NAME", ""Zm9vYmFy"}`.
 
     `:system` can be replaced with a `{:via, adapter}` tuple, where adapter is a module that implements `Confex.Adapter` behaviour.
 

--- a/lib/confex/resolver.ex
+++ b/lib/confex/resolver.ex
@@ -5,7 +5,7 @@ defmodule Confex.Resolver do
   alias Confex.Adapter
   alias Confex.Type
 
-  @known_types [:string, :integer, :float, :boolean, :atom, :module, :list, :charlist]
+  @known_types [:string, :integer, :float, :boolean, :atom, :module, :list, :charlist, :base64]
   @known_adapter_aliases [:system, :system_file]
 
   @doc """

--- a/lib/confex/type.ex
+++ b/lib/confex/type.ex
@@ -31,9 +31,9 @@ defmodule Confex.Type do
   end
 
   def cast(value, :base64) do
-      {:ok, value |> Base.decode64!()}
-    rescue
-      e in ArgumentError -> {:error, e.message}
+    {:ok, value |> Base.decode64!()}
+  rescue
+    e in ArgumentError -> {:error, e.message}
   end
 
   def cast(value, :module) do

--- a/lib/confex/type.ex
+++ b/lib/confex/type.ex
@@ -30,6 +30,14 @@ defmodule Confex.Type do
     {:ok, value}
   end
 
+  def cast(value, :base64) do
+    try do
+      {:ok, value |> Base.decode64!()}
+    rescue
+      e in ArgumentError -> {:error, e.message}
+    end
+  end
+
   def cast(value, :module) do
     {:ok, Module.concat([value])}
   end

--- a/lib/confex/type.ex
+++ b/lib/confex/type.ex
@@ -31,11 +31,9 @@ defmodule Confex.Type do
   end
 
   def cast(value, :base64) do
-    try do
       {:ok, value |> Base.decode64!()}
     rescue
       e in ArgumentError -> {:error, e.message}
-    end
   end
 
   def cast(value, :module) do

--- a/test/unit/confex/type_test.exs
+++ b/test/unit/confex/type_test.exs
@@ -14,7 +14,12 @@ defmodule Confex.TypeTest do
   end
 
   test "cast base64" do
-    assert Type.cast("dfads$424", :base64) == {:error, "non-alphabet digit found: \"$\" (byte 36)"}
+    if Version.match?(System.version(), "> 1.5.0") do
+      assert Type.cast("dfads$424", :base64) == {:error, "non-alphabet digit found: \"$\" (byte 36)"}
+    else
+      assert Type.cast("dfads$424", :base64) == {:error, "incorrect padding"}
+    end
+
     assert Type.cast("onUHyQ==", :base64) == {:ok, <<162, 117, 7, 201>>}
   end
 

--- a/test/unit/confex/type_test.exs
+++ b/test/unit/confex/type_test.exs
@@ -13,6 +13,11 @@ defmodule Confex.TypeTest do
     assert Type.cast("my_string", :string) == {:ok, "my_string"}
   end
 
+  test "cast base64" do
+    assert Type.cast("dfads$424", :base64) == {:error, "non-alphabet digit found: \"$\" (byte 36)"}
+    assert Type.cast("onUHyQ==", :base64) == {:ok, <<162, 117, 7, 201>>}
+  end
+
   test "cast module" do
     assert Type.cast("MyModule", :module) == {:ok, MyModule}
     assert Type.cast("___@@*@#", :module) == {:ok, :"Elixir.___@@*@#"}


### PR DESCRIPTION
Hi there - it's useful when using a crypto lib like https://github.com/bryanhuntesl/cloak_ecto to have the base64 encoded key decoded / validated by the confex - hope this is of use to you. 