### PR TITLE
Add opts argument to resolve_env!/4

### DIFF
--- a/lib/confex.ex
+++ b/lib/confex.ex
@@ -224,20 +224,24 @@ defmodule Confex do
       ...> Confex.resolve_env!(:myapp)
       ** (ArgumentError) can't fetch value for key `:test_var` of application `:myapp`, can not cast "foo" to Integer
 
+  The optional `opts` argument is passed through to the internal call to
+  `Application.put_env/4` and may be used to set the `timeout` and/or
+  `persistent` parameters.
+
   *Warning!* Do not use this function if you want to change your environment
   while VM is running. All `{:system, _}` tuples would be replaced with actual values.
   """
-  @spec resolve_env!(app :: app()) :: [{key(), value()}] | no_return
-  def resolve_env!(app) do
+  @spec resolve_env!(app :: app(), opts :: Keyword.t()) :: [{key(), value()}] | no_return
+  def resolve_env!(app, opts \\ []) do
     app
     |> Application.get_all_env()
-    |> Enum.map(&resolve_and_update_env(app, &1))
+    |> Enum.map(&resolve_and_update_env(app, &1, opts))
   end
 
-  defp resolve_and_update_env(app, {key, config}) do
+  defp resolve_and_update_env(app, {key, config}, opts) do
     case Resolver.resolve(config) do
       {:ok, config} ->
-        :ok = Application.put_env(app, key, config)
+        :ok = Application.put_env(app, key, config, opts)
         {key, config}
 
       {:error, {_reason, message}} ->


### PR DESCRIPTION
This change allows the `persistent` and `timeout` parameters on `Application.put_env/4` to be used when resolving the environment with `Confex.resolve_env/[1, 2]`. This is handy when resolving a full environment in a Distillery release using Confex inside a config provider (see https://hexdocs.pm/distillery/extensibility/config_providers.html).