### PR TITLE
Treat empty values the same as missing values

### DIFF
--- a/lib/confex/adapters/file_from_system_environment.ex
+++ b/lib/confex/adapters/file_from_system_environment.ex
@@ -26,7 +26,11 @@ defmodule Confex.Adapters.FileFromSystemEnvironment do
 
   defp read_value(path) do
     case File.read(path) do
-      {:ok, value} -> {:ok, String.trim_trailing(value, "\n")}
+      {:ok, value} -> 
+        case String.trim_trailing(value, "\n") do
+          "" -> :error
+          trimmed -> {:ok, trimmed}
+        end
       _ -> :error
     end
   end

--- a/lib/confex/adapters/system_environment.ex
+++ b/lib/confex/adapters/system_environment.ex
@@ -18,6 +18,7 @@ defmodule Confex.Adapters.SystemEnvironment do
   def fetch_value(key) do
     case System.get_env(key) do
       nil -> :error
+      "" -> :error
       value -> {:ok, value}
     end
   end

--- a/test/unit/confex/resolver_test.exs
+++ b/test/unit/confex/resolver_test.exs
@@ -121,7 +121,23 @@ defmodule Confex.ResolverTest do
       end
     end
 
-    test "raises when variable can not be casted not exist" do
+    test "raises when string variable is blank" do
+      System.put_env("TESTENV", "")
+
+      on_exit(fn ->
+        System.delete_env("TESTENV")
+      end)
+
+      assert_raise ArgumentError, fn ->
+        Resolver.resolve!(%{key: {:system, "TESTENV"}})
+      end
+    end
+
+    test "allows blank default value when variable does not exist" do
+      assert %{key: ""} == Resolver.resolve!(%{key: {:system, :string, "DOES_NOT_EXIST", ""}})
+    end
+
+    test "raises when variable can not be casted" do
       System.put_env("TESTENV", "abc")
 
       on_exit(fn ->


### PR DESCRIPTION
Sometimes I've ran into issues where a deployment system will set an environment variable to an empty string instead of unsetting it. In this scenario, I'd rather my application crash early and loudly instead of lurching along with weird settings.